### PR TITLE
Implement the ability to inherit cascading deletes

### DIFF
--- a/src/CascadeSoftDeletes.php
+++ b/src/CascadeSoftDeletes.php
@@ -47,7 +47,7 @@ trait CascadeSoftDeletes
      */
     protected function implementsSoftDeletes()
     {
-        return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this));
+        return method_exists($this, 'runSoftDelete');
     }
 
 

--- a/tests/CascadeSoftDeletesIntegrationTest.php
+++ b/tests/CascadeSoftDeletesIntegrationTest.php
@@ -137,6 +137,23 @@ class CascadeSoftDeletesIntegrationTest extends PHPUnit_Framework_TestCase
         $post->delete();
     }
 
+    /** @test */
+    public function it_handles_soft_deletes_inherited_from_a_parent_model()
+    {
+        $post = Tests\Entities\ChildPost::create([
+            'title' => 'Testing child model inheriting model trait',
+            'body'  => 'This should allow a child class to inherit the soft deletes trait',
+        ]);
+
+        $this->attachCommentsToPost($post);
+
+        $post->delete();
+
+        $this->assertNull(Tests\Entities\ChildPost::find($post->id));
+        $this->assertCount(1, Tests\Entities\ChildPost::withTrashed()->where('id', $post->id)->get());
+        $this->assertCount(0, Tests\Entities\Comment::where('post_id', $post->id)->get());
+    }
+
     /**
      * Attach some dummy comments to the given post.
      *

--- a/tests/Entities/ChildPost.php
+++ b/tests/Entities/ChildPost.php
@@ -12,6 +12,6 @@ class ChildPost extends Post
 
     public function comments()
     {
-        return $this->hasMany(Comment::class, 'post_id');
+        return $this->hasMany('Tests\Entities\Comment', 'post_id');
     }
 }

--- a/tests/Entities/ChildPost.php
+++ b/tests/Entities/ChildPost.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+use Tests\Entities\Post;
+use Tests\Entities\Comment;
+
+class ChildPost extends Post
+{
+    protected $table = 'posts';
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class, 'post_id');
+    }
+}


### PR DESCRIPTION
Change the `implementsSoftDeletes` check to see if the `runSoftDelete`
method exists on the class. This will allow a model to inherit from some
parent class using the `SoftDeletes` and `CascadeSoftDeletes` traits,
without having to declare the dependencies on the child.

Resolves #5