### PR TITLE
Add support for forceDelete()

### DIFF
--- a/src/CascadeSoftDeletes.php
+++ b/src/CascadeSoftDeletes.php
@@ -34,7 +34,7 @@ trait CascadeSoftDeletes
             }
 
             foreach ($model->getCascadingDeletes() as $relationship) {
-                $model->{$relationship}()->delete();
+                $model->forceDeleting ? $model->{$relationship}()->forceDelete() : $model->{$relationship}()->delete();
             }
         });
     }

--- a/tests/CascadeSoftDeletesIntegrationTest.php
+++ b/tests/CascadeSoftDeletesIntegrationTest.php
@@ -53,6 +53,22 @@ class CascadeSoftDeletesIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertCount(0, Tests\Entities\Comment::where('post_id', $post->id)->get());
     }
 
+    /** @test */
+    public function it_cascades_deletes_when_force_deleting_a_parent_model()
+    {
+        $post = Tests\Entities\Post::create([
+            'title' => 'How to cascade soft deletes in Laravel',
+            'body'  => 'This is how you cascade soft deletes in Laravel',
+        ]);
+
+        $this->attachCommentsToPost($post);
+
+        $this->assertCount(3, $post->comments);
+        $post->forceDelete();
+        $this->assertCount(0, Tests\Entities\Comment::where('post_id', $post->id)->get());
+        $this->assertCount(0, Tests\Entities\Post::withTrashed()->where('id', $post->id)->get());
+    }
+
     /**
      * @test
      * @expectedException              \LogicException


### PR DESCRIPTION
Hi Michael,

I have found an issue where package couldn't handle situation, when you want to perform an actual DELETE statement to your model.

That's because you want to delete record that is associated with records from other tables with foreign keys so you get a SQL error like this:

```
SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`dbname`.`comments`, CONSTRAINT `comments_review_id_foreign` FOREIGN KEY (`review_id`) REFERENCES `reviews` (`id`)) (SQL: delete from `reviews` where `id` = 1)
```

This little change handle makes this possible now.