### PR TITLE
Readme Code Example Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ class Post extends Model
 
     protected $cascadeDeletes = ['comments'];
 
-	protected $dates = ['deleted_at'];
+    protected $dates = ['deleted_at'];
 
     public function comments()
     {
         return $this->hasMany(Comment::class);
     }
-}    
+}
 ```
 
 Now you can delete an `App\Post` record, and any associated `App\Comment` records will be deleted. If the `App\Comment` record implements the `CascadeSoftDeletes` trait as well, it's children will also be deleted and so on.


### PR DESCRIPTION
Fixes small code example formatting/indentation issue in the README:

![image](https://user-images.githubusercontent.com/177773/39221547-86b9b6d6-47ec-11e8-99f7-be19a24f5d59.png)
