### PR TITLE
Enhancement: declare empty $cascadeDeletes in CascadeSoftDeletes

### DIFF
--- a/src/CascadeSoftDeletes.php
+++ b/src/CascadeSoftDeletes.php
@@ -8,6 +8,8 @@ use LogicException;
 
 trait CascadeSoftDeletes
 {
+    protected $cascadeDeletes = [];
+
     /**
      * Boot the trait.
      *


### PR DESCRIPTION
For more useful work with IDE. For example: autocomplete.

![image](https://user-images.githubusercontent.com/38257723/58093628-9042e900-7bd7-11e9-8f46-62e182516b8d.png)
