### PR TITLE
Support for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "Cascading deletes for Eloquent models that implement soft deletes",
     "type": "utility",
     "require": {
-        "php": "^7.2",
-        "illuminate/database": "^6.0",
-        "illuminate/events": "^6.0"
+        "php": "^7.2.5",
+        "illuminate/database": "^6.0|^7.0",
+        "illuminate/events": "^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"


### PR DESCRIPTION
This adds support for Laravel 6 or 7, as well as increases the PHP requirement to be minimally compatible with both versions.