### PR TITLE
Bump the version on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cascading soft deletes for the Laravel PHP Framework
-## v2.0.0
+## v3.0.0
 
 ![Travis Build Status](https://travis-ci.org/michaeldyrynda/laravel-cascade-soft-deletes.svg?branch=master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/michaeldyrynda/laravel-cascade-soft-deletes/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/michaeldyrynda/laravel-cascade-soft-deletes/?branch=master)


### PR DESCRIPTION
Thanks for this awesome package. I noticed the README version hasn't been changed so this commit bumps the version up to v3.0 to reflect the latest release for Laravel 7.