### PR TITLE
Call relationship directly to allow deletes with lazy loading disabled

### DIFF
--- a/src/CascadeSoftDeletes.php
+++ b/src/CascadeSoftDeletes.php
@@ -117,7 +117,7 @@ trait CascadeSoftDeletes
     protected function getActiveCascadingDeletes()
     {
         return array_filter($this->getCascadingDeletes(), function ($relationship) {
-            return ! is_null($this->{$relationship}());
+            return $this->{$relationship}()->exists();
         });
     }
 }

--- a/src/CascadeSoftDeletes.php
+++ b/src/CascadeSoftDeletes.php
@@ -117,7 +117,7 @@ trait CascadeSoftDeletes
     protected function getActiveCascadingDeletes()
     {
         return array_filter($this->getCascadingDeletes(), function ($relationship) {
-            return ! is_null($this->{$relationship});
+            return ! is_null($this->{$relationship}());
         });
     }
 }


### PR DESCRIPTION
Laravel allows disabling lazy loading in the entire project.

```
// app/Providers/AppServiceProvider.php
 
public function boot()
{
    Model::preventLazyLoading(! app()->isProduction());
}
```

More about this feature: https://laravel-news.com/disable-eloquent-lazy-loading-during-development

With this feature enabled deleting of nested relationships is not working.

Calling the relationship directly and not via the property solves this issue.