### PR TITLE
Update README to remove event priority note

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,6 @@ $post->delete(); // Soft delete the post, which will also trigger the delete() m
 
 Because this trait hooks into the `deleting` Eloquent model event, we can prevent the parent record from being deleted as well as any child records, if any exception is triggered. A `LogicException` will be triggered if the model does not use the `Illuminate\Database\Eloquent\SoftDeletes` trait, or if any of the defined `cascadeDeletes` relationships do not exist, or do not return an instance of `Illuminate\Database\Eloquent\Relations\Relation`.
 
-**Additional Note**:  If you already have existing event listeners in place for a model that is going to cascade soft deletes, you can adjust the priority or firing order of events to have CascadeSoftDeletes fire after your event.  To do this you can set the priority of your deleting event listener to be 1.
-
-`MODEL::observe( MODELObserver::class, 1 );`  The second param is the priority.
-
-`MODEL::deleting( MODELObserver::class, 1 );`
-
-As of right now this is not documented in the Larvel docs, but just know that the default priority is `0` for all listeners, and that `0` is the lowest priority.  Passing a param of greater than `0` to your listener will cause your listener to fire before listeners with default priority of `0`
-
-
 ## Installation
 
 This trait is installed via [Composer](http://getcomposer.org/). To install, simply add to your `composer.json` file:


### PR DESCRIPTION
The event priority had been removed in [Laravel 5.4](https://laravel.com/docs/5.4/upgrade#:~:text=Event%20Priority,an%20unrelated%20handler.). The additional note in the README doesn't work now, so maybe it can be removed.

> 
> **Event Priority**
> 
> Support for event handler "priorities" has been removed. This undocumented feature typically indicates an abuse of the event feature. Instead, consider using a series of synchronous method calls. Alternatively, you may dispatch a new event from within the handler of another event in order to ensure that a given event's handler fires after an unrelated handler.