### PR TITLE
improve memory consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ class Post extends Model
 
     protected $dates = ['deleted_at'];
 
+    protected $fetchMethod = 'get'; // get, cursor, lazy or chunk
+    // protected $chunkSize = 500;
+
     public function comments()
     {
         return $this->hasMany(Comment::class);


### PR DESCRIPTION
Although you have done an amazing job with this package if we have a large dataset it may run out memory because it is trying to get all the records to soft delete them.
This PR is trying to allow and customize how we want to achieve that.

On the `cascadeSoftDeletes` instead of running a `get()` will search for a `fetchMethod` property on the model to perform a `get`, `cursor`, `lazy` or a `chunk` (where the chunk may have a `chunkSize` property).

I hope this helps.
Thoughts?