### PR TITLE
feat: Cascade Soft Restores

### DIFF
--- a/src/CascadeSoftRestores.php
+++ b/src/CascadeSoftRestores.php
@@ -5,7 +5,6 @@ namespace Dyrynda\Database\Support;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 
@@ -100,11 +99,13 @@ trait CascadeSoftRestores
             };
         }
 
-        throw new InvalidArgumentException(sprintf(
+        $error = sprintf(
             '%s does not support restoring %s relationships.',
             __CLASS__,
             get_class($relation)
-        ));
+        );
+        Log::info($error);
+        throw new InvalidArgumentException($error);
     }
 
     /**


### PR DESCRIPTION
 Design/Changes:
- implementation of the cascade soft delete design, but with laravel's restore() action
- this makes it possible to both cascade delete and restore.
- caveat is as noted in the readme, that cascade soft restore catches all child model rows with deleted_at datetime >= that of the parent model. This still works great for most situations, but should be noted nonetheless.

Testing:
- use the laravel cascade soft delete feature on a laravel model with _child_ models defined by a one-to-many relationship within the parent model.
- ensure all models have `use SoftDeletes`, and any models that will cascade need to have `CascadeSoftDeletes` and `CascadeSoftRestores` as well.
- trigger laravel's _deleting()_ action on a parent model
  - cascade soft delete should work successfully. you can check your database tables.
- use laravel's _restoring()_ action on a parent model (likely the same you deleted above)
  - cascade soft restore should work successfully. you can check your database tables.